### PR TITLE
Add ability to disable DNS hostnames, DNS support, and creation of NAT gateways

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,8 +19,8 @@ data "aws_region" "current" {}
 resource aws_vpc "vpc" {
   cidr_block           = "${var.cidr_range}"
   instance_tenancy     = "${var.default_tenancy}"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  enable_dns_hostnames = "${var.enable_dns_hostnames}"
+  enable_dns_support   = "${var.enable_dns_support}"
 
   tags = "${merge(local.base_tags, map("Name", var.vpc_name), var.custom_tags)}"
 }

--- a/main.tf
+++ b/main.tf
@@ -51,14 +51,14 @@ resource aws_internet_gateway "igw" {
 #############
 
 resource aws_eip "nat_eip" {
-  count      = "${var.az_count}"
+  count      = "${var.build_nat_gateways ? var.az_count : 0}"
   vpc        = true
   depends_on = ["aws_internet_gateway.igw"]
   tags       = "${merge(local.base_tags, map("Name", format("%s-NATEIP%d", var.vpc_name, count.index + 1)), var.custom_tags)}"
 }
 
 resource aws_nat_gateway "nat" {
-  count         = "${var.az_count}"
+  count         = "${var.build_nat_gateways ? var.az_count : 0}"
   allocation_id = "${element(aws_eip.nat_eip.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.public_subnet.*.id, count.index)}"
   depends_on    = ["aws_internet_gateway.igw"]
@@ -110,7 +110,7 @@ resource aws_route "public_routes" {
 }
 
 resource aws_route "private_routes" {
-  count                  = "${var.az_count}"
+  count                  = "${var.build_nat_gateways ? var.az_count : 0}"
   route_table_id         = "${element(aws_route_table.private_route_table.*.id, count.index)}"
   nat_gateway_id         = "${element(aws_nat_gateway.nat.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,18 @@ variable "domain_name_servers" {
   default     = ["AmazonProvidedDNS"]
 }
 
+variable "enable_dns_hostnames" {
+  description = "Whether or not to enable DNS hostnames for the VPC"
+  type        = "string"
+  default     = "true"
+}
+
+variable "enable_dns_support" {
+  description = "Whether or not to enable DNS support for the VPC"
+  type        = "string"
+  default     = "true"
+}
+
 #####################
 # Subnet Core Options
 #####################

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,12 @@ variable "build_flow_logs" {
   type        = "string"
 }
 
+variable "build_nat_gateways" {
+  description = "Whether or not to build a NAT gateway per AZ"
+  default     = "true"
+  type        = "string"
+}
+
 variable "build_vpn" {
   description = "Whether or not to build a VPN gateway"
   default     = "false"


### PR DESCRIPTION
I'm refactoring some existing templates to use the Rackspace VPC base network and noticed that these settings were unavailable.

This PR makes it possible to disable any of the three components mentioned in the title, but keeps the existing functionality as the default in order to not break BC.