### PR TITLE
Implement IPv6 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,41 +29,47 @@ By default only `vpc_name` is required to be set. Unless changed `aws_region` de
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| az_count | Number of AZs to utilize for the subnets | string | `2` | no |
-| build_flow_logs | Whether or not to build flow log components | string | `false` | no |
-| build_nat_gateways | Whether or not to build a NAT gateway per AZ | string | `true` | no |
-| build_vpn | Whether or not to build a VPN gateway | string | `false` | no |
-| cidr_range | CIDR range for the VPC | string | `172.18.0.0/16` | no |
-| custom_azs | A list of AZs that VPC resources will reside in | list | `<list>` | no |
-| custom_tags | Optional tags to be applied on top of the base tags on all resources | map | `<map>` | no |
-| default_tenancy | Default tenancy for instances. Either multi-tenant (default) or single-tenant (dedicated) | string | `default` | no |
-| domain_name | Custom domain name for the VPC | string | `` | no |
-| domain_name_servers | Array of custom domain name servers | list | `<list>` | no |
-| enable_dns_hostnames | Whether or not to enable DNS hostnames for the VPC | string | `true` | no |
-| enable_dns_support | Whether or not to enable DNS support for the VPC | string | `true` | no |
+| vpc\_name | Name for the VPC | string | - | yes |
+| az\_count | Number of AZs to utilize for the subnets | string | `2` | no |
+| build\_flow\_logs | Whether or not to build flow log components | string | `false` | no |
+| build\_nat\_gateways | Whether or not to build a NAT gateway per AZ | string | `true` | no |
+| build\_vpn | Whether or not to build a VPN gateway | string | `false` | no |
+| cidr\_range | CIDR range for the VPC | string | `172.18.0.0/16` | no |
+| custom\_azs | A list of AZs that VPC resources will reside in | list | `<list>` | no |
+| custom\_tags | Optional tags to be applied on top of the base tags on all resources | map | `<map>` | no |
+| default\_tenancy | Default tenancy for instances. Either multi-tenant (default) or single-tenant (dedicated) | string | `default` | no |
+| domain\_name | Custom domain name for the VPC | string | `` | no |
+| domain\_name\_servers | Array of custom domain name servers | list | `<list>` | no |
+| enable\_dns\_hostnames | Whether or not to enable DNS hostnames for the VPC | string | `true` | no |
+| enable\_dns\_support | Whether or not to enable DNS support for the VPC | string | `true` | no |
+| enable\_ipv6 | Whether or not to enable IPv6 support for the VPC | string | `false` | no |
 | environment | Application environment for which this network is being created. e.g. Development/Production | string | `Development` | no |
-| private_cidr_ranges | An array of CIDR ranges to use for private subnets | list | `<list>` | no |
-| private_subnet_names | Text that will be included in generated name for private subnets. Given the default value of `["Private"]`, subnet names in the form \"<vpc_name>-Private<count+1>\", e.g. \"MyVpc-Public2\" will be produced. Otherwise, given a list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | list | `<list>` | no |
-| private_subnets_per_az | Number of private subnets to create in each AZ. NOTE: This value, when multiplied by the value of `az_count`, should not exceed the length of the `private_cidr_ranges` list! | string | `1` | no |
-| public_cidr_ranges | An array of CIDR ranges to use for public subnets | list | `<list>` | no |
-| public_subnet_names | Text that will be included in generated name for public subnets. Given the default value of `["Public"]`, subnet names in the form \"<vpc_name>-Public<count+1>\", e.g. \"MyVpc-Public1\" will be produced. Otherwise, given a list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | list | `<list>` | no |
-| public_subnets_per_az | Number of public subnets to create in each AZ. NOTE: This value, when multiplied by the value of `az_count`, should not exceed the length of the `public_cidr_ranges` list! | string | `1` | no |
-| spoke_vpc | Whether or not the VPN gateway is a spoke of a Transit VPC | string | `false` | no |
-| vpc_name | Name for the VPC | string | - | yes |
+| private\_cidr\_ranges | An array of CIDR ranges to use for private subnets | list | `<list>` | no |
+| private\_subnet\_names | Text that will be included in generated name for private subnets. Given the default value of `["Private"]`, subnet names in the form \"<vpc_name>-Private<count+1>\", e.g. \"MyVpc-Public2\" will be produced. Otherwise, given a list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | list | `<list>` | no |
+| private\_subnets\_per\_az | Number of private subnets to create in each AZ. NOTE: This value, when multiplied by the value of `az_count`, should not exceed the length of the `private_cidr_ranges` list! | string | `1` | no |
+| public\_cidr\_ranges | An array of CIDR ranges to use for public subnets | list | `<list>` | no |
+| public\_subnet\_names | Text that will be included in generated name for public subnets. Given the default value of `["Public"]`, subnet names in the form \"<vpc_name>-Public<count+1>\", e.g. \"MyVpc-Public1\" will be produced. Otherwise, given a list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | list | `<list>` | no |
+| public\_subnets\_per\_az | Number of public subnets to create in each AZ. NOTE: This value, when multiplied by the value of `az_count`, should not exceed the length of the `public_cidr_ranges` list! | string | `1` | no |
+| spoke\_vpc | Whether or not the VPN gateway is a spoke of a Transit VPC | string | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| default_sg | The ID of the default SG for the VPC |
-| flowlog_log_group_arn | The ARN of the flow log CloudWatch log group if one was created |
-| internet_gateway | The ID of the Internet Gateway |
-| nat_gateway | The ID of the NAT Gateway if one was created |
-| nat_gateway_eip | The IP of the NAT Gateway if one was created |
-| private_route_tables | The IDs for the private route tables |
-| private_subnets | The IDs for the private subnets |
-| public_route_tables | The IDs for the public route tables |
-| public_subnets | The IDs of the public subnets |
-| vpc_id | The ID of the VPC |
-| vpn_gateway | The ID of the VPN gateway if one was created |
+| default\_sg | The ID of the default SG for the VPC |
+| egress\_only\_internet\_gateway\_id | The ID of the Egress Only Internet Gateway if one was created |
+| flowlog\_log\_group\_arn | The ARN of the flow log CloudWatch log group if one was created |
+| internet\_gateway | The ID of the Internet Gateway |
+| ipv6\_association\_id | The ID of the VPC IPv6 Association ID if one was created |
+| ipv6\_cidr\_block | The IPv6 CIDR block of the VPC if one was created |
+| nat\_gateway | The ID of the NAT Gateway if one was created |
+| nat\_gateway\_eip | The IP of the NAT Gateway if one was created |
+| private\_route\_tables | The IDs for the private route tables |
+| private\_subnet\_ipv6\_cidr\_block\_association\_ids | The association IDs of the IPv6 CIDR block for the private subnets |
+| private\_subnets | The IDs for the private subnets |
+| public\_route\_tables | The IDs for the public route tables |
+| public\_subnet\_ipv6\_cidr\_block\_association\_ids | The association IDs of the IPv6 CIDR block of the public subnets |
+| public\_subnets | The IDs of the public subnets |
+| vpc\_id | The ID of the VPC |
+| vpn\_gateway | The ID of the VPN gateway if one was created |
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ By default only `vpc_name` is required to be set. Unless changed `aws_region` de
 | nat\_gateway | The ID of the NAT Gateway if one was created |
 | nat\_gateway\_eip | The IP of the NAT Gateway if one was created |
 | private\_route\_tables | The IDs for the private route tables |
+| private\_dualstack\_subnets | The IDs of the private dual stack subnets |
 | private\_subnet\_ipv6\_cidr\_block\_association\_ids | The association IDs of the IPv6 CIDR block for the private subnets |
 | private\_subnets | The IDs for the private subnets |
 | public\_route\_tables | The IDs for the public route tables |
+| public\_dualstack\_subnets | The IDs of the public dual stack subnets |
 | public\_subnet\_ipv6\_cidr\_block\_association\_ids | The association IDs of the IPv6 CIDR block of the public subnets |
 | public\_subnets | The IDs of the public subnets |
 | vpc\_id | The ID of the VPC |

--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ By default only `vpc_name` is required to be set. Unless changed `aws_region` de
 | domain\_name\_servers | Array of custom domain name servers | list | `<list>` | no |
 | enable\_dns\_hostnames | Whether or not to enable DNS hostnames for the VPC | string | `true` | no |
 | enable\_dns\_support | Whether or not to enable DNS support for the VPC | string | `true` | no |
-| enable\_ipv6 | Whether or not to enable IPv6 support for the VPC. Supersedes prepare_ipv6 | string | `false` | no |
+| enable\_ipv6 | Whether or not to assign an IPv6 subnet to the VPC | string | `false` | no |
 | enable\_public\_ipv6 | Whether or not to enable IPv6 support for the VPC's public subnets. Requires enable_ipv6 to be set to true | string | `false` | no |
 | enable\_private\_ipv6 | Whether or not to enable IPv6 support for the VPC's private subnets. Requires enable_ipv6 to be set to true | string | `false` | no |
 | environment | Application environment for which this network is being created. e.g. Development/Production | string | `Development` | no |
-| prepare\_ipv6 | Whether or not to prepare for IPv6 support for the VPC. This will assign an IPv6 subnet to the VPC, but will not do anything else. Superseded by enable_ipv6 | string | `false` | no |
 | private\_cidr\_ranges | An array of CIDR ranges to use for private subnets | list | `<list>` | no |
 | private\_subnet\_names | Text that will be included in generated name for private subnets. Given the default value of `["Private"]`, subnet names in the form \"<vpc_name>-Private<count+1>\", e.g. \"MyVpc-Public2\" will be produced. Otherwise, given a list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | list | `<list>` | no |
 | private\_subnets\_per\_az | Number of private subnets to create in each AZ. NOTE: This value, when multiplied by the value of `az_count`, should not exceed the length of the `private_cidr_ranges` list! | string | `1` | no |

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ By default only `vpc_name` is required to be set. Unless changed `aws_region` de
 | domain\_name\_servers | Array of custom domain name servers | list | `<list>` | no |
 | enable\_dns\_hostnames | Whether or not to enable DNS hostnames for the VPC | string | `true` | no |
 | enable\_dns\_support | Whether or not to enable DNS support for the VPC | string | `true` | no |
-| enable\_ipv6 | Whether or not to enable IPv6 support for the VPC | string | `false` | no |
+| enable\_ipv6 | Whether or not to enable IPv6 support for the VPC. Supersedes prepare_ipv6 | string | `false` | no |
+| enable\_public\_ipv6 | Whether or not to enable IPv6 support for the VPC's public subnets. Requires enable_ipv6 to be set to true | string | `false` | no |
+| enable\_private\_ipv6 | Whether or not to enable IPv6 support for the VPC's private subnets. Requires enable_ipv6 to be set to true | string | `false` | no |
 | environment | Application environment for which this network is being created. e.g. Development/Production | string | `Development` | no |
+| prepare\_ipv6 | Whether or not to prepare for IPv6 support for the VPC. This will assign an IPv6 subnet to the VPC, but will not do anything else. Superseded by enable_ipv6 | string | `false` | no |
 | private\_cidr\_ranges | An array of CIDR ranges to use for private subnets | list | `<list>` | no |
 | private\_subnet\_names | Text that will be included in generated name for private subnets. Given the default value of `["Private"]`, subnet names in the form \"<vpc_name>-Private<count+1>\", e.g. \"MyVpc-Public2\" will be produced. Otherwise, given a list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | list | `<list>` | no |
 | private\_subnets\_per\_az | Number of private subnets to create in each AZ. NOTE: This value, when multiplied by the value of `az_count`, should not exceed the length of the `private_cidr_ranges` list! | string | `1` | no |

--- a/examples/ipv6.tf
+++ b/examples/ipv6.tf
@@ -4,8 +4,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
-  vpc_name            = "MyVPC"
+  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
+  vpc_name = "MyVPC"
 
   enable_ipv6         = "true"
   enable_public_ipv6  = "true"

--- a/examples/ipv6.tf
+++ b/examples/ipv6.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  version = "~> 1.2"
+  region  = "us-west-2"
+}
+
+module "vpc" {
+  source      = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
+  vpc_name    = "MyVPC"
+  enable_ipv6 = "true"
+}

--- a/examples/ipv6.tf
+++ b/examples/ipv6.tf
@@ -6,7 +6,7 @@ provider "aws" {
 module "vpc" {
   source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
   vpc_name            = "MyVPC"
-  prepare_ipv6        = "true"
+
   enable_ipv6         = "true"
   enable_public_ipv6  = "true"
   enable_private_ipv6 = "true"

--- a/examples/ipv6.tf
+++ b/examples/ipv6.tf
@@ -4,7 +4,10 @@ provider "aws" {
 }
 
 module "vpc" {
-  source      = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
-  vpc_name    = "MyVPC"
-  enable_ipv6 = "true"
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
+  vpc_name            = "MyVPC"
+  prepare_ipv6        = "true"
+  enable_ipv6         = "true"
+  enable_public_ipv6  = "true"
+  enable_private_ipv6 = "true"
 }

--- a/main.tf
+++ b/main.tf
@@ -104,11 +104,11 @@ resource aws_nat_gateway "nat" {
 #############
 
 resource aws_subnet "public_subnet" {
-  count                           = "${var.enable_ipv6 == "true" ? var.enable_public_ipv6 == "true" ? 0 : var.az_count * var.public_subnets_per_az : var.az_count * var.public_subnets_per_az}"
-  vpc_id                          = "${aws_vpc.vpc.id}"
-  cidr_block                      = "${var.public_cidr_ranges[count.index]}"
-  availability_zone               = "${element(local.azs, count.index)}"
-  map_public_ip_on_launch         = true
+  count                   = "${var.enable_ipv6 == "true" ? var.enable_public_ipv6 == "true" ? 0 : var.az_count * var.public_subnets_per_az : var.az_count * var.public_subnets_per_az}"
+  vpc_id                  = "${aws_vpc.vpc.id}"
+  cidr_block              = "${var.public_cidr_ranges[count.index]}"
+  availability_zone       = "${element(local.azs, count.index)}"
+  map_public_ip_on_launch = true
 
   tags = "${merge(
     local.base_tags,
@@ -126,11 +126,11 @@ resource aws_subnet "public_subnet" {
 }
 
 resource aws_subnet "private_subnet" {
-  count                           = "${var.enable_ipv6 == "true" ? var.enable_private_ipv6 == "true" ? 0 : var.az_count * var.private_subnets_per_az : var.az_count * var.private_subnets_per_az}"
-  vpc_id                          = "${aws_vpc.vpc.id}"
-  cidr_block                      = "${var.private_cidr_ranges[count.index]}"
-  availability_zone               = "${element(local.azs, count.index)}"
-  map_public_ip_on_launch         = false
+  count                   = "${var.enable_ipv6 == "true" ? var.enable_private_ipv6 == "true" ? 0 : var.az_count * var.private_subnets_per_az : var.az_count * var.private_subnets_per_az}"
+  vpc_id                  = "${aws_vpc.vpc.id}"
+  cidr_block              = "${var.private_cidr_ranges[count.index]}"
+  availability_zone       = "${element(local.azs, count.index)}"
+  map_public_ip_on_launch = false
 
   tags = "${merge(
     local.base_tags,

--- a/main.tf
+++ b/main.tf
@@ -104,9 +104,10 @@ resource aws_nat_gateway "nat" {
 #############
 
 resource aws_subnet "public_subnet" {
-  count                           = "${var.enable_ipv6 == "true" ? 2 * var.az_count * var.public_subnets_per_az : var.az_count * var.public_subnets_per_az}"
+  count                           = "${var.az_count * var.public_subnets_per_az}"
   vpc_id                          = "${aws_vpc.vpc.id}"
-  cidr_block                      = "${var.enable_ipv6 == "true" ? element(compact(concat(var.public_cidr_ranges, list(cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, count.index)))), count.index) : var.public_cidr_ranges[count.index]}"
+  cidr_block                      = "${var.public_cidr_ranges[count.index]}"
+  ipv6_cidr_block                 = "${var.enable_ipv6 == "true" ? cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, count.index + 1) : ""}"
   availability_zone               = "${element(local.azs, count.index)}"
   map_public_ip_on_launch         = true
   assign_ipv6_address_on_creation = "${var.enable_ipv6}"
@@ -127,9 +128,10 @@ resource aws_subnet "public_subnet" {
 }
 
 resource aws_subnet "private_subnet" {
-  count                           = "${var.enable_ipv6 == "true" ? 2 * var.az_count * var.private_subnets_per_az : var.az_count * var.private_subnets_per_az}"
+  count                           = "${var.az_count * var.private_subnets_per_az}"
   vpc_id                          = "${aws_vpc.vpc.id}"
-  cidr_block                      = "${var.enable_ipv6 == "true" ? element(compact(concat(var.private_cidr_ranges, list(cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, count.index)))), count.index) : var.private_cidr_ranges[count.index]}"
+  cidr_block                      = "${var.private_cidr_ranges[count.index]}"
+  ipv6_cidr_block                 = "${var.enable_ipv6 == "true" ? cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, count.index + 100) : ""}"
   availability_zone               = "${element(local.azs, count.index)}"
   map_public_ip_on_launch         = false
   assign_ipv6_address_on_creation = "${var.enable_ipv6}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -76,12 +76,12 @@ output "flowlog_log_group_arn" {
 # IPv6 Conditional Resource Outputs
 
 output "ipv6_association_id" {
-  value       = "${var.prepare_ipv6 == "true" ? aws_vpc.vpc.ipv6_association_id : var.enable_ipv6 == "true" ? aws_vpc.vpc.ipv6_association_id : ""}"
+  value       = "${var.enable_ipv6 == "true" ? aws_vpc.vpc.ipv6_association_id : ""}"
   description = "The ID of the VPC IPv6 Association ID if one was created"
 }
 
 output "ipv6_cidr_block" {
-  value       = "${var.prepare_ipv6 == "true" ? aws_vpc.vpc.ipv6_cidr_block : var.enable_ipv6 == "true" ? aws_vpc.vpc.ipv6_cidr_block : ""}"
+  value       = "${var.enable_ipv6 == "true" ? aws_vpc.vpc.ipv6_cidr_block : ""}"
   description = "The IPv6 CIDR block of the VPC if one was created"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -72,3 +72,34 @@ output "flowlog_log_group_arn" {
   value       = "${ join(" ", aws_cloudwatch_log_group.flowlog_group.*.arn) }"
   description = "The ARN of the flow log CloudWatch log group if one was created"
 }
+
+# IPv6 Conditional Resource Outputs
+
+output "ipv6_association_id" {
+  value       = "${var.enable_ipv6 == "true" ? aws_vpc.vpc.ipv6_association_id : ""}"
+  description = "The ID of the VPC IPv6 Association ID if one was created"
+}
+
+output "ipv6_cidr_block" {
+  value       = "${var.enable_ipv6 == "true" ? aws_vpc.vpc.ipv6_cidr_block : ""}"
+  description = "The IPv6 CIDR block of the VPC if one was created"
+}
+
+output "public_subnet_ipv6_cidr_block_association_ids" {
+  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.public_subnet.*.ipv6_cidr_block_association_id, list("")), 0) : ""}"
+  description = "The association IDs of the IPv6 CIDR block of the public subnets"
+
+  depends_on = ["aws_route_table_association.public_route_association"]
+}
+
+output "private_subnet_ipv6_cidr_block_association_ids" {
+  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.private_subnet.*.ipv6_cidr_block_association_id, list("")), 0) : ""}"
+  description = "The association IDs of the IPv6 CIDR block for the private subnets"
+
+  depends_on = ["aws_route_table_association.private_route_association"]
+}
+
+output "egress_only_internet_gateway_id" {
+  value       = "${var.enable_ipv6 == "true" ? aws_egress_only_internet_gateway.egress_igw.id : ""}"
+  description = "The ID of the Egress Only Internet Gateway if one was created"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -100,6 +100,6 @@ output "private_subnet_ipv6_cidr_block_association_ids" {
 }
 
 output "egress_only_internet_gateway_id" {
-  value       = "${var.enable_ipv6 == "true" ? aws_egress_only_internet_gateway.egress_igw.id : ""}"
+  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_egress_only_internet_gateway.egress_igw.*.id, list("")), 0) : ""}"
   description = "The ID of the Egress Only Internet Gateway if one was created"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,17 +23,17 @@ output "internet_gateway" {
 
 ## Since terraform will build across all modules synchronously, there is a possibility instances will be
 ## built and bootstrapping will fail before routes are created. Therefore we will add the dependon for
-## the subnets output, to make sure the routes are created first so bootstraping will wait for the routes.
+## the subnets output, to make sure the routes are created first so bootstrapping will wait for the routes.
 
 output "public_subnets" {
-  value       = "${aws_subnet.public_subnet.*.id}"
+  value       = "${var.enable_ipv6 == "false" ? aws_subnet.public_subnet.*.id : ""}"
   description = "The IDs of the public subnets"
 
   depends_on = ["aws_route_table_association.public_route_association"]
 }
 
 output "private_subnets" {
-  value       = "${aws_subnet.private_subnet.*.id}"
+  value       = "${var.enable_ipv6 == "false" ? aws_subnet.private_subnet.*.id : ""}"
   description = "The IDs for the private subnets"
 
   depends_on = ["aws_route_table_association.private_route_association"]
@@ -85,15 +85,29 @@ output "ipv6_cidr_block" {
   description = "The IPv6 CIDR block of the VPC if one was created"
 }
 
+output "public_dualstack_subnets" {
+  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.public_dualstack_subnet.*.id, list("")), 0) : ""}"
+  description = "The IDs of the public dual stack subnets"
+
+  depends_on = ["aws_route_table_association.public_route_association"]
+}
+
+output "private_dualstack_subnets" {
+  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.private_dualstack_subnet.*.id, list("")), 0) : ""}"
+  description = "The IDs for the private dual stack subnets"
+
+  depends_on = ["aws_route_table_association.private_route_association"]
+}
+
 output "public_subnet_ipv6_cidr_block_association_ids" {
-  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.public_subnet.*.ipv6_cidr_block_association_id, list("")), 0) : ""}"
+  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.public_dualstack_subnet.*.ipv6_cidr_block_association_id, list("")), 0) : ""}"
   description = "The association IDs of the IPv6 CIDR block of the public subnets"
 
   depends_on = ["aws_route_table_association.public_route_association"]
 }
 
 output "private_subnet_ipv6_cidr_block_association_ids" {
-  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.private_subnet.*.ipv6_cidr_block_association_id, list("")), 0) : ""}"
+  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.private_dualstack_subnet.*.ipv6_cidr_block_association_id, list("")), 0) : ""}"
   description = "The association IDs of the IPv6 CIDR block for the private subnets"
 
   depends_on = ["aws_route_table_association.private_route_association"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,14 +26,14 @@ output "internet_gateway" {
 ## the subnets output, to make sure the routes are created first so bootstrapping will wait for the routes.
 
 output "public_subnets" {
-  value       = "${var.enable_ipv6 == "false" ? aws_subnet.public_subnet.*.id : ""}"
+  value       = "${var.enable_ipv6 == "false" ? element(concat(aws_subnet.public_subnet.*.id, list("")), 0) : ""}"
   description = "The IDs of the public subnets"
 
   depends_on = ["aws_route_table_association.public_route_association"]
 }
 
 output "private_subnets" {
-  value       = "${var.enable_ipv6 == "false" ? aws_subnet.private_subnet.*.id : ""}"
+  value       = "${var.enable_ipv6 == "false" ? element(concat(aws_subnet.private_subnet.*.id, list("")), 0) : ""}"
   description = "The IDs for the private subnets"
 
   depends_on = ["aws_route_table_association.private_route_association"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,14 +26,14 @@ output "internet_gateway" {
 ## the subnets output, to make sure the routes are created first so bootstrapping will wait for the routes.
 
 output "public_subnets" {
-  value       = "${var.enable_ipv6 == "false" ? element(concat(aws_subnet.public_subnet.*.id, list("")), 0) : ""}"
+  value       = "${var.enable_ipv6 == "false" ? var.enable_public_ipv6 == "false" ? element(concat(aws_subnet.public_subnet.*.id, list("")), 0) : "" : ""}"
   description = "The IDs of the public subnets"
 
   depends_on = ["aws_route_table_association.public_route_association"]
 }
 
 output "private_subnets" {
-  value       = "${var.enable_ipv6 == "false" ? element(concat(aws_subnet.private_subnet.*.id, list("")), 0) : ""}"
+  value       = "${var.enable_ipv6 == "false" ? var.enable_private_ipv6 == "false" ? element(concat(aws_subnet.private_subnet.*.id, list("")), 0) : "" : ""}"
   description = "The IDs for the private subnets"
 
   depends_on = ["aws_route_table_association.private_route_association"]
@@ -76,44 +76,44 @@ output "flowlog_log_group_arn" {
 # IPv6 Conditional Resource Outputs
 
 output "ipv6_association_id" {
-  value       = "${var.enable_ipv6 == "true" ? aws_vpc.vpc.ipv6_association_id : ""}"
+  value       = "${var.prepare_ipv6 == "true" ? aws_vpc.vpc.ipv6_association_id : var.enable_ipv6 == "true" ? aws_vpc.vpc.ipv6_association_id : ""}"
   description = "The ID of the VPC IPv6 Association ID if one was created"
 }
 
 output "ipv6_cidr_block" {
-  value       = "${var.enable_ipv6 == "true" ? aws_vpc.vpc.ipv6_cidr_block : ""}"
+  value       = "${var.prepare_ipv6 == "true" ? aws_vpc.vpc.ipv6_cidr_block : var.enable_ipv6 == "true" ? aws_vpc.vpc.ipv6_cidr_block : ""}"
   description = "The IPv6 CIDR block of the VPC if one was created"
 }
 
 output "public_dualstack_subnets" {
-  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.public_dualstack_subnet.*.id, list("")), 0) : ""}"
+  value       = "${var.enable_ipv6 == "true" ? var.enable_public_ipv6 == "true" ? element(concat(aws_subnet.public_dualstack_subnet.*.id, list("")), 0) : "" : ""}"
   description = "The IDs of the public dual stack subnets"
 
   depends_on = ["aws_route_table_association.public_route_association"]
 }
 
 output "private_dualstack_subnets" {
-  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.private_dualstack_subnet.*.id, list("")), 0) : ""}"
+  value       = "${var.enable_ipv6 == "true" ? var.enable_private_ipv6 == "true" ? element(concat(aws_subnet.private_dualstack_subnet.*.id, list("")), 0) : "" : ""}"
   description = "The IDs for the private dual stack subnets"
 
   depends_on = ["aws_route_table_association.private_route_association"]
 }
 
 output "public_subnet_ipv6_cidr_block_association_ids" {
-  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.public_dualstack_subnet.*.ipv6_cidr_block_association_id, list("")), 0) : ""}"
+  value       = "${var.enable_ipv6 == "true" ? var.enable_public_ipv6 == "true" ? element(concat(aws_subnet.public_dualstack_subnet.*.ipv6_cidr_block_association_id, list("")), 0) : "" : ""}"
   description = "The association IDs of the IPv6 CIDR block of the public subnets"
 
   depends_on = ["aws_route_table_association.public_route_association"]
 }
 
 output "private_subnet_ipv6_cidr_block_association_ids" {
-  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_subnet.private_dualstack_subnet.*.ipv6_cidr_block_association_id, list("")), 0) : ""}"
+  value       = "${var.enable_ipv6 == "true" ? var.enable_private_ipv6 == "true" ? element(concat(aws_subnet.private_dualstack_subnet.*.ipv6_cidr_block_association_id, list("")), 0) : "" : ""}"
   description = "The association IDs of the IPv6 CIDR block for the private subnets"
 
   depends_on = ["aws_route_table_association.private_route_association"]
 }
 
 output "egress_only_internet_gateway_id" {
-  value       = "${var.enable_ipv6 == "true" ? element(concat(aws_egress_only_internet_gateway.egress_igw.*.id, list("")), 0) : ""}"
+  value       = "${var.enable_ipv6 == "true" ? var.enable_private_ipv6 == "true" ? element(concat(aws_egress_only_internet_gateway.egress_igw.*.id, list("")), 0) : "" : ""}"
   description = "The ID of the Egress Only Internet Gateway if one was created"
 }

--- a/tests/test3/main.tf
+++ b/tests/test3/main.tf
@@ -8,5 +8,8 @@ module "vpc" {
 
   vpc_name = "Test3VPC"
 
-  enable_ipv6 = "true"
+  prepare_ipv6        = "true"
+  enable_ipv6         = "true"
+  enable_public_ipv6  = "true"
+  enable_private_ipv6 = "true"
 }

--- a/tests/test3/main.tf
+++ b/tests/test3/main.tf
@@ -8,7 +8,6 @@ module "vpc" {
 
   vpc_name = "Test3VPC"
 
-  prepare_ipv6        = "true"
   enable_ipv6         = "true"
   enable_public_ipv6  = "true"
   enable_private_ipv6 = "true"

--- a/tests/test3/main.tf
+++ b/tests/test3/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  version = "~> 1.2"
+  region  = "us-west-2"
+}
+
+module "vpc" {
+  source = "../../module"
+
+  vpc_name = "Test3VPC"
+
+  enable_ipv6 = "true"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "enable_dns_support" {
 variable "enable_ipv6" {
   description = "Whether or not to enable IPv6 support for the VPC"
   type        = "string"
-  default     = "true"
+  default     = "false"
 }
 
 #####################

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,12 @@ variable "enable_dns_support" {
   default     = "true"
 }
 
+variable "enable_ipv6" {
+  description = "Whether or not to enable IPv6 support for the VPC"
+  type        = "string"
+  default     = "false"
+}
+
 #####################
 # Subnet Core Options
 #####################

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "enable_dns_support" {
 variable "enable_ipv6" {
   description = "Whether or not to enable IPv6 support for the VPC"
   type        = "string"
-  default     = "false"
+  default     = "true"
 }
 
 #####################

--- a/variables.tf
+++ b/variables.tf
@@ -59,14 +59,8 @@ variable "enable_dns_support" {
   default     = "true"
 }
 
-variable "prepare_ipv6" {
-  description = "Whether or not to prepare for IPv6 support for the VPC. This will assign an IPv6 subnet to the VPC, but will not do anything else. Superseded by enable_ipv6"
-  type        = "string"
-  default     = "false"
-}
-
 variable "enable_ipv6" {
-  description = "Whether or not to enable IPv6 support for the VPC. Supersedes prepare_ipv6"
+  description = "Whether or not to assign an IPv6 subnet to the VPC"
   type        = "string"
   default     = "false"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,12 @@ variable "enable_dns_support" {
   default     = "true"
 }
 
+variable "prepare_ipv6" {
+  description = "Whether or not to prepare for IPv6 support for the VPC. This will assign an IPv6 subnet to the VPC, but will not do anything else"
+  type        = "string"
+  default     = "false"
+}
+
 variable "enable_ipv6" {
   description = "Whether or not to enable IPv6 support for the VPC"
   type        = "string"

--- a/variables.tf
+++ b/variables.tf
@@ -60,13 +60,25 @@ variable "enable_dns_support" {
 }
 
 variable "prepare_ipv6" {
-  description = "Whether or not to prepare for IPv6 support for the VPC. This will assign an IPv6 subnet to the VPC, but will not do anything else"
+  description = "Whether or not to prepare for IPv6 support for the VPC. This will assign an IPv6 subnet to the VPC, but will not do anything else. Superseded by enable_ipv6"
   type        = "string"
   default     = "false"
 }
 
 variable "enable_ipv6" {
-  description = "Whether or not to enable IPv6 support for the VPC"
+  description = "Whether or not to enable IPv6 support for the VPC. Supersedes prepare_ipv6"
+  type        = "string"
+  default     = "false"
+}
+
+variable "enable_public_ipv6" {
+  description = "Whether or not to enable IPv6 support for the VPC's public subnets. Requires enable_ipv6 to be set to true"
+  type        = "string"
+  default     = "false"
+}
+
+variable "enable_private_ipv6" {
+  description = "Whether or not to enable IPv6 support for the VPC's private subnets. Requires enable_ipv6 to be set to true"
   type        = "string"
   default     = "false"
 }


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s): N/A

##### Summary of change(s): This PR will perform the following:
- Associate an AWS-assigned IPv6 /56 subnet to the VPC ("The VPC CIDR block size is fixed at /56.)
- Based on the above subnet, assign an IPv6 /64 subnet to every IPv4 subnet ("The subnet CIDR block size is fixed at /64.")
- Create routes for the above
- Create an egress-only Internet Gateway (IPv6 subnets are not compatible with NAT Gateway)

Documentation for above can be found here: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-ip-addressing.html

Since you cannot specify the IPv6 range you receive, I made an arbitrary decision to just start with the 100th /64 subnet for public subnets. This reflects what we've done with public vs private subnets within Exact, couldn't really figure out a better way to do it. 

There may be a case for moving this into its own submodule, considering the impact. 

Note that this pull request will not implement IPv6-only resources. At the moment there's too many things in AWS that rely on IPv4 addressing that I felt it would be a waste of effort and time. 

##### Will the change trigger resource destruction or replacement? If yes, please provide justification: 
Yes.

There are two issues: 
- When switching between IPv4-only and dual stack subnets, the subnets and route table associations will have to be recreated. This is because you cannot conditionally specify a ipv6_cidr_block. `terraform state mv` should be a sufficient workaround.
- To allow for the above, there should be a separate variable for assign_generated_ipv6_cidr_block in aws_vpc. Else, Terraform will be unable to calculate the proper CIDR blocks for the IPv6 subnets when setting enable_ipv6 to true. 
Another option is to set assign_generated_ipv6_cidr_block to true by default, which is costless and harmless. 

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No. 

##### If input variables or output variables have changed or has been added, have you updated the README?
Yes.

##### Do examples need to be updated based on changes?
I have created an IPv6.tf example, but this will need to be updated with the correct version reference. 

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.