### PR TITLE
Added option to build internet gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module sets up basic network components for an account in a specific region
 
 ```
 module "vpc" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.5"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
 
  vpc_name = "MyVPC"
 }
@@ -30,7 +30,8 @@ By default only `vpc_name` is required to be set. Unless changed `aws_region` de
 |------|-------------|:----:|:-----:|:-----:|
 | az\_count | Number of AZs to utilize for the subnets | string | `"2"` | no |
 | build\_flow\_logs | Whether or not to build flow log components in cloud watch logs | string | `"false"` | no |
-| build\_nat\_gateways | Whether or not to build a NAT gateway per AZ | string | `"true"` | no |
+| build\_igw | Whether or not to build an internet gateway.  If disabled, no public subnets or route tables, internet gateway, or NAT Gateways will be created. | string | `"true"` | no |
+| build\_nat\_gateways | Whether or not to build a NAT gateway per AZ.  if `build_igw` is set to false, this value is ignored. | string | `"true"` | no |
 | build\_s3\_flow\_logs | Whether or not to build flow log components in s3 | string | `"false"` | no |
 | build\_vpn | Whether or not to build a VPN gateway | string | `"false"` | no |
 | cidr\_range | CIDR range for the VPC | string | `"172.18.0.0/16"` | no |

--- a/examples/basic_usage.tf
+++ b/examples/basic_usage.tf
@@ -4,6 +4,6 @@ provider "aws" {
 }
 
 module "vpc" {
-  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
+  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
   vpc_name = "MyVPC"
 }

--- a/examples/custom_azs.tf
+++ b/examples/custom_azs.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
 
   vpc_name   = "MyVPC"
   custom_azs = ["us-west-2a", "us-west-2b"]

--- a/examples/vpn_provided.tf
+++ b/examples/vpn_provided.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
 
   vpc_name  = "MyVPC"
   build_vpn = true

--- a/tests/test3/main.tf
+++ b/tests/test3/main.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  version = "~> 1.2"
+  region  = "us-west-2"
+}
+
+module "vpc" {
+  source = "../../module"
+
+  vpc_name  = "Test1VPC"
+  build_igw = "false"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -217,8 +217,18 @@ variable "logging_bucket_force_destroy" {
   default     = "false"
 }
 
+variable "build_igw" {
+  description = <<EOF
+Whether or not to build an internet gateway.  If disabled, no public subnets or route tables, internet gateway,
+or NAT Gateways will be created.
+EOF
+
+  default = "true"
+  type    = "string"
+}
+
 variable "build_nat_gateways" {
-  description = "Whether or not to build a NAT gateway per AZ"
+  description = "Whether or not to build a NAT gateway per AZ.  if `build_igw` is set to false, this value is ignored."
   default     = "true"
   type        = "string"
 }


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
#22 
##### Summary of change(s):
- Added a conditional input variable named "build_igw" that determines whether or not to build an internet gateway, defaulted to true..  When set to false, the following resources will not be created:
  - Internet Gateway
  - Public Subnets
  - Public Route Tables and Route Entries
  - Public Route Associations
  - NAT Gateways & associated Elastic IPs
  - Default Route Entries for private routes.
- Adds additional test build for this use case.
- Updates example version pinning.

Changes originally submitted by @cygnus8595 
##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Readme updated
##### Do examples need to be updated based on changes?
No
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.