### PR TITLE
allow retention configuration on CWL for flow logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ module "vpc" {
 }
 ```
 
-Full working references are available at [examples](examples)  
+Full working references are available at [examples](examples)
 ## Default Resources
 
 By default only `vpc_name` is required to be set. Unless changed `aws_region` defaults to `us-west-2` and will need to be updated for other regions. `source` will also need to be declared depending on where the module lives. Given default settings the following resources are created:
@@ -47,12 +47,13 @@ The following module variables were updated to better meet current Rackspace sty
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | az\_count | Number of AZs to utilize for the subnets | `number` | `2` | no |
-| build\_flow\_logs | Whether or not to build flow log components in cloud watch logs | `bool` | `false` | no |
+| build\_flow\_logs | Whether or not to build flow log components in Cloudwatch Logs | `bool` | `false` | no |
 | build\_igw | Whether or not to build an internet gateway.  If disabled, no public subnets or route tables, internet gateway,<br>or NAT Gateways will be created. | `bool` | `true` | no |
 | build\_nat\_gateways | Whether or not to build a NAT gateway per AZ.  if `build_igw` is set to false, this value is ignored. | `bool` | `true` | no |
 | build\_s3\_flow\_logs | Whether or not to build flow log components in s3 | `bool` | `false` | no |
 | build\_vpn | Whether or not to build a VPN gateway | `bool` | `false` | no |
 | cidr\_range | CIDR range for the VPC | `string` | `"172.18.0.0/19"` | no |
+| cloudwatch\_flowlog\_retention | The number of days to retain flowlogs in CLoudwatch Logs. Valid values are: [0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]. A value of `0` will retain indefinitely. | `number` | `14` | no |
 | custom\_azs | A list of AZs that VPC resources will reside in | `list(string)` | `[]` | no |
 | default\_tenancy | Default tenancy for instances. Either multi-tenant (default) or single-tenant (dedicated) | `string` | `"default"` | no |
 | domain\_name | Custom domain name for the VPC | `string` | `""` | no |
@@ -64,9 +65,8 @@ The following module variables were updated to better meet current Rackspace sty
 | logging\_bucket\_encryption | Enable default bucket encryption. i.e. AES256 or aws:kms | `string` | `"AES256"` | no |
 | logging\_bucket\_encryption\_kms\_mster\_key | The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse\_algorithm as aws:kms. | `string` | `""` | no |
 | logging\_bucket\_force\_destroy | Whether all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. ie. true | `bool` | `false` | no |
-| logging\_bucket\_name | Bucket name to store s3 flow logs. If empty, to create random bucket name. In conjuction with build\_s3\_flow\_logs | `string` | `""` | no |
+| logging\_bucket\_name | Bucket name to store s3 flow logs. If empty, a random bucket name is generated. Use in conjuction with `build_s3_flow_logs` | `string` | `""` | no |
 | logging\_bucket\_prefix | The prefix for the location in the S3 bucket. If you don't specify a prefix, the access logs are stored in the root of the bucket. | `string` | `""` | no |
-| logging\_bucket\_retention | The number of days to retain load balancer logs. 0 to ratain forever. | `number` | `14` | no |
 | name | Name prefix for the VPC and related resources | `string` | n/a | yes |
 | private\_cidr\_ranges | An array of CIDR ranges to use for private subnets | `list(string)` | <pre>[<br>  "172.18.16.0/22",<br>  "172.18.20.0/22",<br>  "172.18.24.0/22"<br>]<br></pre> | no |
 | private\_subnet\_names | Text that will be included in generated name for private subnets. Given the default value of `["Private"]`, subnet<br>names in the form \"<vpc\_name>-Private<count+1>\", e.g. \"MyVpc-Public2\" will be produced. Otherwise, given a<br>list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using<br>the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | `list(string)` | <pre>[<br>  "Private"<br>]<br></pre> | no |
@@ -76,6 +76,7 @@ The following module variables were updated to better meet current Rackspace sty
 | public\_subnet\_names | Text that will be included in generated name for public subnets. Given the default value of `["Public"]`, subnet<br>names in the form \"<vpc\_name>-Public<count+1>\", e.g. \"MyVpc-Public1\" will be produced. Otherwise, given a<br>list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using<br>the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | `list(string)` | <pre>[<br>  "Public"<br>]<br></pre> | no |
 | public\_subnet\_tags | A list of maps containing tags to be applied to public subnets. List should either be the same length as the number of AZs to apply different tags per set of subnets, or a length of 1 to apply the same tags across all public subnets. | `list(map(string))` | <pre>[<br>  {}<br>]<br></pre> | no |
 | public\_subnets\_per\_az | Number of public subnets to create in each AZ. NOTE: This value, when multiplied by the value of `az_count`,<br>should not exceed the length of the `public_cidr_ranges` list! | `number` | `1` | no |
+| s3\_flowlog\_retention | The number of days to retain flowlogs in s3. A value of `0` will retain indefinitely. | `number` | `14` | no |
 | spoke\_vpc | Whether or not the VPN gateway is a spoke of a Transit VPC | `bool` | `false` | no |
 | tags | Optional tags to be applied on top of the base tags on all resources | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -333,7 +333,7 @@ resource "aws_s3_bucket" "vpc_log_bucket" {
     prefix  = var.logging_bucket_prefix
 
     expiration {
-      days = var.logging_bucket_retention
+      days = var.s3_flowlog_retention
     }
   }
 }
@@ -350,7 +350,8 @@ resource "aws_flow_log" "cw_vpc_log" {
 resource "aws_cloudwatch_log_group" "flowlog_group" {
   count = var.build_flow_logs ? 1 : 0
 
-  name = "${var.name}-FlowLogs"
+  name              = "${var.name}-FlowLogs"
+  retention_in_days = var.cloudwatch_flowlog_retention
 }
 
 resource "aws_iam_role" "flowlog_role" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "az_count" {
 }
 
 variable "build_flow_logs" {
-  description = "Whether or not to build flow log components in cloud watch logs"
+  description = "Whether or not to build flow log components in Cloudwatch Logs"
   default     = false
   type        = bool
 }
@@ -42,6 +42,12 @@ variable "cidr_range" {
   description = "CIDR range for the VPC"
   type        = string
   default     = "172.18.0.0/19"
+}
+
+variable "cloudwatch_flowlog_retention" {
+  description = "The number of days to retain flowlogs in CLoudwatch Logs. Valid values are: [0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]. A value of `0` will retain indefinitely."
+  type        = number
+  default     = 14
 }
 
 variable "custom_azs" {
@@ -111,7 +117,7 @@ variable "logging_bucket_force_destroy" {
 }
 
 variable "logging_bucket_name" {
-  description = "Bucket name to store s3 flow logs. If empty, to create random bucket name. In conjuction with build_s3_flow_logs"
+  description = "Bucket name to store s3 flow logs. If empty, a random bucket name is generated. Use in conjuction with `build_s3_flow_logs`"
   type        = string
   default     = ""
 }
@@ -120,12 +126,6 @@ variable "logging_bucket_prefix" {
   description = "The prefix for the location in the S3 bucket. If you don't specify a prefix, the access logs are stored in the root of the bucket."
   type        = string
   default     = ""
-}
-
-variable "logging_bucket_retention" {
-  description = "The number of days to retain load balancer logs. 0 to ratain forever."
-  type        = number
-  default     = 14
 }
 
 variable "name" {
@@ -211,6 +211,12 @@ EOF
 
   type    = number
   default = 1
+}
+
+variable "s3_flowlog_retention" {
+  description = "The number of days to retain flowlogs in s3. A value of `0` will retain indefinitely."
+  type        = number
+  default     = 14
 }
 
 variable "spoke_vpc" {


### PR DESCRIPTION
##### Corresponding Issue(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/267

Change(s)** section

##### Summary of change(s):
- added  variable  for flow log retention  to CWL
- set log retention as an attribute for CWL backed Flow logs

##### Reason for Change(s):
- cost savings
- added flexibility

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
yes
##### Do examples need to be updated based on changes?
No
