### PR TITLE
Implement Single NAT mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@ This module sets up basic network components for an account in a specific region
 
 ```HCL
 module "vpc" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.2"
 
- vpc_name = "MyVPC"
+  vpc_name = "MyVPC"
 }
 ```
 
-Full working references are available at [examples](examples)
+ Full working references are available at [examples](examples)
 ## Default Resources
 
 By default only `vpc_name` is required to be set. Unless changed `aws_region` defaults to `us-west-2` and will need to be updated for other regions. `source` will also need to be declared depending on where the module lives. Given default settings the following resources are created:
 
-- VPC Flow Logs  
-- 2 AZs with public/private subnets from the list of 3 static CIDRs ranges available for each as defaults  
-- Public/private subnets with the count related to custom\_azs if defined or region AZs automatically calculated by Terraform otherwise  
-- NAT Gateways will be created in each AZ's first public subnet  
-- EIPs will be created in all public subnets for NAT gateways to use  
-- Route Tables, including routes to NAT gateways if applicable
+ - VPC Flow Logs
+ - 2 AZs with public/private subnets from the list of 3 static CIDRs ranges available for each as defaults
+ - Public/private subnets with the count related to custom\_azs if defined or region AZs automatically calculated by Terraform otherwise
+ - NAT Gateways will be created in each AZ's first public subnet
+ - EIPs will be created in all public subnets for NAT gateways to use
+ - Route Tables, including routes to NAT gateways if applicable
 
 ## Terraform 0.12 upgrade
 
@@ -33,14 +33,14 @@ made when upgrading from a previous release to version 0.12.0 or higher.
 
 The following module variables were updated to better meet current Rackspace style guides:
 
-- `custom_tags` -> `tags`  
+- `custom_tags` -> `tags`
 - `vpc_name` -> `name`
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.1.0 |
+| aws | >= 2.7.0 |
 
 ## Inputs
 
@@ -48,7 +48,7 @@ The following module variables were updated to better meet current Rackspace sty
 |------|-------------|------|---------|:-----:|
 | az\_count | Number of AZs to utilize for the subnets | `number` | `2` | no |
 | build\_flow\_logs | Whether or not to build flow log components in Cloudwatch Logs | `bool` | `false` | no |
-| build\_igw | Whether or not to build an internet gateway.  If disabled, no public subnets or route tables, internet gateway,<br>or NAT Gateways will be created. | `bool` | `true` | no |
+| build\_igw | Whether or not to build an internet gateway.  If disabled, no public subnets or route tables, internet gateway, or NAT Gateways will be created. | `bool` | `true` | no |
 | build\_nat\_gateways | Whether or not to build a NAT gateway per AZ.  if `build_igw` is set to false, this value is ignored. | `bool` | `true` | no |
 | build\_s3\_flow\_logs | Whether or not to build flow log components in s3 | `bool` | `false` | no |
 | build\_vpn | Whether or not to build a VPN gateway | `bool` | `false` | no |
@@ -57,7 +57,7 @@ The following module variables were updated to better meet current Rackspace sty
 | custom\_azs | A list of AZs that VPC resources will reside in | `list(string)` | `[]` | no |
 | default\_tenancy | Default tenancy for instances. Either multi-tenant (default) or single-tenant (dedicated) | `string` | `"default"` | no |
 | domain\_name | Custom domain name for the VPC | `string` | `""` | no |
-| domain\_name\_servers | Array of custom domain name servers | `list(string)` | <pre>[<br>  "AmazonProvidedDNS"<br>]<br></pre> | no |
+| domain\_name\_servers | Array of custom domain name servers | `list(string)` | <pre>[<br>  "AmazonProvidedDNS"<br>]</pre> | no |
 | enable\_dns\_hostnames | Whether or not to enable DNS hostnames for the VPC | `bool` | `true` | no |
 | enable\_dns\_support | Whether or not to enable DNS support for the VPC | `bool` | `true` | no |
 | environment | Application environment for which this network is being created. e.g. Development/Production | `string` | `"Development"` | no |
@@ -68,15 +68,16 @@ The following module variables were updated to better meet current Rackspace sty
 | logging\_bucket\_name | Bucket name to store s3 flow logs. If empty, a random bucket name is generated. Use in conjuction with `build_s3_flow_logs` | `string` | `""` | no |
 | logging\_bucket\_prefix | The prefix for the location in the S3 bucket. If you don't specify a prefix, the access logs are stored in the root of the bucket. | `string` | `""` | no |
 | name | Name prefix for the VPC and related resources | `string` | n/a | yes |
-| private\_cidr\_ranges | An array of CIDR ranges to use for private subnets | `list(string)` | <pre>[<br>  "172.18.16.0/22",<br>  "172.18.20.0/22",<br>  "172.18.24.0/22"<br>]<br></pre> | no |
-| private\_subnet\_names | Text that will be included in generated name for private subnets. Given the default value of `["Private"]`, subnet<br>names in the form \"<vpc\_name>-Private<count+1>\", e.g. \"MyVpc-Public2\" will be produced. Otherwise, given a<br>list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using<br>the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | `list(string)` | <pre>[<br>  "Private"<br>]<br></pre> | no |
-| private\_subnet\_tags | A list of maps containing tags to be applied to private subnets. List should either be the same length as the number of AZs to apply different tags per set of subnets, or a length of 1 to apply the same tags across all private subnets. | `list(map(string))` | <pre>[<br>  {}<br>]<br></pre> | no |
+| private\_cidr\_ranges | An array of CIDR ranges to use for private subnets | `list(string)` | <pre>[<br>  "172.18.16.0/22",<br>  "172.18.20.0/22",<br>  "172.18.24.0/22"<br>]</pre> | no |
+| private\_subnet\_names | Text that will be included in generated name for private subnets. Given the default value of `["Private"]`, subnet<br>names in the form \"<vpc\_name>-Private<count+1>\", e.g. \"MyVpc-Public2\" will be produced. Otherwise, given a<br>list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using<br>the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | `list(string)` | <pre>[<br>  "Private"<br>]</pre> | no |
+| private\_subnet\_tags | A list of maps containing tags to be applied to private subnets. List should either be the same length as the number of AZs to apply different tags per set of subnets, or a length of 1 to apply the same tags across all private subnets. | `list(map(string))` | <pre>[<br>  {}<br>]</pre> | no |
 | private\_subnets\_per\_az | Number of private subnets to create in each AZ. NOTE: This value, when multiplied by the value of `az_count`,<br>should not exceed the length of the `private_cidr_ranges` list! | `number` | `1` | no |
-| public\_cidr\_ranges | An array of CIDR ranges to use for public subnets | `list(string)` | <pre>[<br>  "172.18.0.0/22",<br>  "172.18.4.0/22",<br>  "172.18.8.0/22"<br>]<br></pre> | no |
-| public\_subnet\_names | Text that will be included in generated name for public subnets. Given the default value of `["Public"]`, subnet<br>names in the form \"<vpc\_name>-Public<count+1>\", e.g. \"MyVpc-Public1\" will be produced. Otherwise, given a<br>list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using<br>the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | `list(string)` | <pre>[<br>  "Public"<br>]<br></pre> | no |
-| public\_subnet\_tags | A list of maps containing tags to be applied to public subnets. List should either be the same length as the number of AZs to apply different tags per set of subnets, or a length of 1 to apply the same tags across all public subnets. | `list(map(string))` | <pre>[<br>  {}<br>]<br></pre> | no |
+| public\_cidr\_ranges | An array of CIDR ranges to use for public subnets | `list(string)` | <pre>[<br>  "172.18.0.0/22",<br>  "172.18.4.0/22",<br>  "172.18.8.0/22"<br>]</pre> | no |
+| public\_subnet\_names | Text that will be included in generated name for public subnets. Given the default value of `["Public"]`, subnet<br>names in the form \"<vpc\_name>-Public<count+1>\", e.g. \"MyVpc-Public1\" will be produced. Otherwise, given a<br>list of names with length the same as the value of `az_count`, the first `az_count` subnets will be named using<br>the first string in the list, the second `az_count` subnets will be named using the second string, and so on. | `list(string)` | <pre>[<br>  "Public"<br>]</pre> | no |
+| public\_subnet\_tags | A list of maps containing tags to be applied to public subnets. List should either be the same length as the number of AZs to apply different tags per set of subnets, or a length of 1 to apply the same tags across all public subnets. | `list(map(string))` | <pre>[<br>  {}<br>]</pre> | no |
 | public\_subnets\_per\_az | Number of public subnets to create in each AZ. NOTE: This value, when multiplied by the value of `az_count`,<br>should not exceed the length of the `public_cidr_ranges` list! | `number` | `1` | no |
 | s3\_flowlog\_retention | The number of days to retain flowlogs in s3. A value of `0` will retain indefinitely. | `number` | `14` | no |
+| single\_nat | Deploy VPC in single NAT mode. | `bool` | `false` | no |
 | spoke\_vpc | Whether or not the VPN gateway is a spoke of a Transit VPC | `bool` | `false` | no |
 | tags | Optional tags to be applied on top of the base tags on all resources | `map(string)` | `{}` | no |
 

--- a/examples/basic_usage.tf
+++ b/examples/basic_usage.tf
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.2"
 
   name = "MyVPC"
 }

--- a/examples/custom_azs.tf
+++ b/examples/custom_azs.tf
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.2"
 
   name       = "MyVPC"
   custom_azs = ["us-west-2a", "us-west-2b"]

--- a/examples/vpn_provided.tf
+++ b/examples/vpn_provided.tf
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.2"
 
   name      = "MyVPC"
   build_vpn = true

--- a/variables.tf
+++ b/variables.tf
@@ -11,13 +11,9 @@ variable "build_flow_logs" {
 }
 
 variable "build_igw" {
-  description = <<EOF
-Whether or not to build an internet gateway.  If disabled, no public subnets or route tables, internet gateway,
-or NAT Gateways will be created.
-EOF
-
-  type    = bool
-  default = true
+  description = "Whether or not to build an internet gateway.  If disabled, no public subnets or route tables, internet gateway, or NAT Gateways will be created."
+  type        = bool
+  default     = true
 }
 
 variable "build_nat_gateways" {
@@ -217,6 +213,12 @@ variable "s3_flowlog_retention" {
   description = "The number of days to retain flowlogs in s3. A value of `0` will retain indefinitely."
   type        = number
   default     = 14
+}
+
+variable "single_nat" {
+  description = "Deploy VPC in single NAT mode."
+  type        = bool
+  default     = false
 }
 
 variable "spoke_vpc" {


### PR DESCRIPTION
##### Corresponding Issue(s):
 - fixes rackspace-infrastructure-automation/aws-terraform-internal#268
[MPCSUPENG-920](https://jira.rax.io/browse/MPCSUPENG-920)

##### Summary of change(s):
- Adds `single_nat` module variable.  Wen set to true, only a single NAT appliance is created, regardless of how many AZs are in use
- Updated minimum AWS provider version to 2.7.0
- Minor variable description and readme formatting changes.
##### Reason for Change(s):

- See linked issues

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No.

##### If input variables or output variables have changed or has been added, have you updated the README?
Readme is up to date
##### Do examples need to be updated based on changes?
Example pinnings updated

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
