### PR TITLE
AWS Provider 3.0 Support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -411,7 +411,7 @@ resource "aws_iam_role_policy" "flowlog_policy" {
         "logs:DescribeLogStreams"
       ],
       "Effect": "Allow",
-      "Resource": "${aws_cloudwatch_log_group.flowlog_group[0].arn}"
+      "Resource": "${replace(aws_cloudwatch_log_group.flowlog_group[0].arn, ":*", "")}:*"
     }
   ]
 }


### PR DESCRIPTION
* The flow log role needs to be changed due to how ARNs and `:*` are handled. In 2.x the :* is automatically added. In 3.0 it isn't. This handles both cases and replace prevents a duplication in 2.x

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
