### PR TITLE
Update VPC Flowlog IAM policy to prevent recreation of CW Log Group after deletion

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -374,21 +374,16 @@ resource "aws_iam_role" "flowlog_role" {
 
   name = "${var.name}-FlowLogsRole"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "vpc-flow-logs.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Principal = { Service = "vpc-flow-logs.amazonaws.com" },
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
 
 }
 
@@ -398,23 +393,19 @@ resource "aws_iam_role_policy" "flowlog_policy" {
   name = "${var.name}-FlowLogsPolicy"
   role = aws_iam_role.flowlog_role[0].id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
-      ],
-      "Effect": "Allow",
-      "Resource": "${replace(aws_cloudwatch_log_group.flowlog_group[0].arn, ":*", "")}:*"
-    }
-  ]
-}
-EOF
-
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ],
+        Effect   = "Allow",
+        Resource = "${replace(aws_cloudwatch_log_group.flowlog_group[0].arn, ":*", "")}:*"
+      }
+    ]
+  })
 }


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-2056](https://jira.rax.io/browse/MPCSUPENG-2056)

##### Summary of change(s):
- Updates IAM policies to use jsonencode method instead of multiline strings.
- Updates VPC FlowLogs IAM Policy to remove ability to create log groups.
  - This permission was allowing the Log Group to be recreated after its destruction when in flight FlowLog messages were processed.

##### Reason for Change(s):

- Undesired behavior of Log Group being recreated after destruction.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
N/A
##### Do examples need to be updated based on changes?
N/A

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
