### PR TITLE
Added flowlog_log_group_name output

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ No Modules.
 |------|-------------|
 | default\_sg | The ID of the default SG for the VPC |
 | flowlog\_log\_group\_arn | The ARN of the flow log CloudWatch log group if one was created |
+| flowlog\_log\_group\_name | The name of the flow log CloudWatch log group if one was created |
 | internet\_gateway | The ID of the Internet Gateway |
 | nat\_gateway | The ID of the NAT Gateway if one was created |
 | nat\_gateway\_ids | The ID of the NAT Gateway if one was created |

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "flowlog_log_group_arn" {
   value       = join(" ", aws_cloudwatch_log_group.flowlog_group.*.arn)
 }
 
+output "flowlog_log_group_name" {
+  description = "The name of the flow log CloudWatch log group if one was created"
+  value       = aws_cloudwatch_log_group.flowlog_group.name
+}
+
 output "internet_gateway" {
   description = "The ID of the Internet Gateway"
   value       = aws_internet_gateway.igw.*.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "flowlog_log_group_arn" {
 
 output "flowlog_log_group_name" {
   description = "The name of the flow log CloudWatch log group if one was created"
-  value       = aws_cloudwatch_log_group.flowlog_group.name
+  value       = var.build_flow_logs ? aws_cloudwatch_log_group.flowlog_group[0].name : ""
 }
 
 output "internet_gateway" {


### PR DESCRIPTION
##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section

##### Summary of change(s):
- added output of the VPC flowlog log group name

##### Reason for Change(s):
- to create a dependency for resources depending on the VPC flowlog log group, like e.g. log subscriptions

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
- no

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
- no

##### If input variables or output variables have changed or has been added, have you updated the README?
- yes

##### Do examples need to be updated based on changes?
- no

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
